### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 <p align="center">An AI-powered browser automation server implementing Model Context Protocol (MCP) for natural language browser control and web research.</p>
 
+<a href="https://glama.ai/mcp/servers/@302ai/302_browser_use_mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@302ai/302_browser_use_mcp/badge" alt="302AI BrowserUse Server MCP server" />
+</a>
+
 <p align="center"><a href="https://www.npmjs.com/package/@302ai/browser-use-mcp" target="blank"><img src="https://file.302.ai/gpt/imgs/github/20250102/72a57c4263944b73bf521830878ae39a.png" /></a></p >
 
 <p align="center"><a href="README_zh.md">中文</a> | <a href="README.md">English</a> | <a href="README_ja.md">日本語</a></p>


### PR DESCRIPTION
This PR adds a badge for the [302AI BrowserUse MCP Server](https://glama.ai/mcp/servers/@302ai/302_browser_use_mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@302ai/302_browser_use_mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@302ai/302_browser_use_mcp/badge" alt="302AI BrowserUse Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.